### PR TITLE
[CS WM] Check PowerShell version and give advice

### DIFF
--- a/hermes-upload.ps1
+++ b/hermes-upload.ps1
@@ -1,6 +1,13 @@
 #---------------------------------------------
 # Zip functions modified from http://www.technologytoolbox.com/blog/jjameson/archive/2012/02/28/zip-a-folder-using-powershell.aspx
 #---------------------------------------------
+
+If ((Test-Path variable:\PSVersionTable) -And ($PSVersionTable.PSVersion.Major -lt 4)) {
+   Throw "You are running an old version of PowerShell. Please update to at least version 4." +
+         "`r`n" + "Please see the following link:" +
+         "`r`n" + "http://social.technet.microsoft.com/wiki/contents/articles/21016.how-to-install-windows-powershell-4-0.aspx"
+}
+
 function CountZipItems(
     [__ComObject] $zipFile)
 {


### PR DESCRIPTION
Our use of System.IO.FileStream and System.Net.WebRequestMethods+Ftp requires PowerShell 4.0. Now we check the PowerShell version and give instructions if it's too old.

[Pivotal story](https://www.pivotaltracker.com/story/show/75526476)
