### PR TITLE
Force TLS 1.2

### DIFF
--- a/hermes-upload.ps1
+++ b/hermes-upload.ps1
@@ -1,4 +1,9 @@
 #---------------------------------------------
+# Force use of TLS 1.2
+#---------------------------------------------
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+#---------------------------------------------
 # Zip functions modified from http://www.technologytoolbox.com/blog/jjameson/archive/2012/02/28/zip-a-folder-using-powershell.aspx
 #---------------------------------------------
 


### PR DESCRIPTION
In order to work with the new infrastructure that doesn't allow downgrades (for security reasons), we need to force clients to use TLS 1.2. Adding this configuration setting at the top does the trick.